### PR TITLE
add timeout option, document retries option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ socket.query({
 
 Create a new DNS socket instance. The `options` object includes:
 
-- `retries` <Number>: Number of total query attempts made during `timeout`. Default: 5.
-- `socket` <Object>: A custom dgram socket. Default: A `'udp4'` socket.
-- `timeout` <Number>: Total timeout in milliseconds after which a `'timeout'` event is emitted. Default: 7500.
+- `retries` *Number*: Number of total query attempts made during `timeout`. Default: 5.
+- `socket` *Object*: A custom dgram socket. Default: A `'udp4'` socket.
+- `timeout` *Number*: Total timeout in milliseconds after which a `'timeout'` event is emitted. Default: 7500.
 
 #### `socket.on('query', query, port, host)`
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,11 @@ socket.query({
 
 #### `var socket = dns([options])`
 
-Create a new DNS socket instance. Options include:
+Create a new DNS socket instance. The `options` object includes:
 
-``` js
-{
-  socket: customDgramSocket
-}
-```
+- `retries` <Number>: Number of total query attempts made during `timeout`. Default: 5.
+- `socket` <Object>: A custom dgram socket. Default: A `'udp4'` socket.
+- `timeout` <Number>: Total timeout in milliseconds after which a `'timeout'` event is emitted. Default: 7500.
 
 #### `socket.on('query', query, port, host)`
 

--- a/index.js
+++ b/index.js
@@ -38,9 +38,7 @@ function DNS (opts) {
   }
 
   function onlistening () {
-    var timeSlices = self._triesArray.reduce(function (prev, curr) {
-      return prev + curr
-    }, 0)
+    var timeSlices = self._triesArray.reduce(add, 0)
     self._interval = setInterval(ontimeout, Math.round(self.timeout / timeSlices))
     self.emit('listening')
   }
@@ -221,6 +219,10 @@ function nextTick (cb, err) {
   process.nextTick(function () {
     cb(err)
   })
+}
+
+function add (a, b) {
+  return a + b
 }
 
 function getTriesArray (retries) {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function DNS (opts) {
   var self = this
 
   this.retries = opts.retries || 5
+  this.timeout = opts.timeout || 7500
   this.destroyed = false
   this.inflight = 0
   this.socket = opts.socket || dgram.createSocket('udp4')
@@ -25,6 +26,7 @@ function DNS (opts) {
   this._ids = []
   this._queries = []
   this._interval = null
+  this._triesArray = getTriesArray(this.retries) // default: [2, 4, 8, 16] = .5s, 1s, 2s, 4s
 
   function onerror (err) {
     if (err.code === 'EACCES' || err.code === 'EADDRINUSE') self.emit('error', err)
@@ -36,7 +38,10 @@ function DNS (opts) {
   }
 
   function onlistening () {
-    self._interval = setInterval(ontimeout, 250)
+    var timeSlices = self._triesArray.reduce(function (prev, curr) {
+      return prev + curr
+    }, 0)
+    self._interval = setInterval(ontimeout, Math.round(self.timeout / timeSlices))
     self.emit('listening')
   }
 
@@ -192,7 +197,7 @@ DNS.prototype.query = function (query, port, host, cb) {
   if (this._queries.length === i) this._queries.push(null)
 
   var buffer = packet.encode(query)
-  var tries = [3, 4, 8, 16] // ~1s, 1s, 2s, 4s
+  var tries = this._triesArray
 
   if (this.retries < tries.length) tries = tries.slice(0, this.retries)
 
@@ -216,4 +221,13 @@ function nextTick (cb, err) {
   process.nextTick(function () {
     cb(err)
   })
+}
+
+function getTriesArray (retries) {
+  var ret = []
+  if (retries <= 1) return ret
+  for (var i = 1; i <= retries - 1; i++) {
+    ret.push(Math.pow(2, i))
+  }
+  return ret
 }


### PR DESCRIPTION
Retries are now chronologically spaced using expotential backoff. E.g.
on the default five retries, attempts will be made after 2/32, 4/32,
8/32 and 16/32 of the total timeout value which has been changed
slightly from the previous 7750ms to 7500ms.
