### PR TITLE
_triesArray is now always sliced prior to being included in _queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,9 +197,7 @@ DNS.prototype.query = function (query, port, host, cb) {
   if (this._queries.length === i) this._queries.push(null)
 
   var buffer = packet.encode(query)
-  var tries = this._triesArray
-
-  if (this.retries < tries.length) tries = tries.slice(0, this.retries)
+  var tries = this._triesArray.slice(0)
 
   this._ids[i] = id
   this._queries[i] = {


### PR DESCRIPTION
Removed conditional slice in .query that would never be called and replaced it with a slice that is always called otherwise a reference to this._triesArray was being included in the _queries array and subsequently being destroyed by the normal operation of _ontimeout.   This resulted in the emptying of this._triesArray and failure of subsequent queries.