### PR TITLE
Large internal changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Emitted when a dns response is received. The response is a [dns-packet](https://
 
 #### `var id = socket.query(query, port, host, [callback])`
 
-Send a dns query. When the remote replies the callback is called with `(err, response, query)` and an response is emitted as well. If the query times out the callback is called with an error.
+Send a dns query. If host is omitted it defaults to `127.0.0.1`. When the remote replies the callback is called with `(err, response, query)` and an response is emitted as well. If the query times out the callback is called with an error.
 The `host` parameter can be an array, during resolve the lib will randomly select one host.
 
 Returns the query id

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Create a new DNS socket instance. The `options` object includes:
 - `retries` *Number*: Number of total query attempts made during `timeout`. Default: 5.
 - `socket` *Object*: A custom dgram socket. Default: A `'udp4'` socket.
 - `timeout` *Number*: Total timeout in milliseconds after which a `'timeout'` event is emitted. Default: 7500.
+- `maxQueries` *Number*: Each request has an id, this is stored as static sized array. maxQueries is the size of this array, limiting the max number of inflight requests. Default: 10000.
+- `maxRedirects` *Number*: If you query for a single `A` record and get back `CNAME`, the lib will try to follow the chain and resolve the `CNAME` to A. The maximum number of steps is defined by the `maxRedirects`. Default: 0
+- `timeoutChecks` *Number*: Timeouts are checked each `timeoutChecks` ms, for large number of parallel request, you might want to increase this number. Default: `timeout` / 10
 
 #### `socket.on('query', query, port, host)`
 
@@ -41,9 +44,10 @@ Emitted when a dns query is received. The query is a [dns-packet](https://github
 
 Emitted when a dns response is received. The response is a [dns-packet](https://github.com/mafintosh/dns-packet)
 
-#### `var id = socket.query(query, port, [host], [callback])`
+#### `var id = socket.query(query, port, host, [callback])`
 
-Send a dns query. If host is omitted it defaults to localhost. When the remote replies the callback is called with `(err, response, query)` and an response is emitted as well. If the query times out the callback is called with an error.
+Send a dns query. When the remote replies the callback is called with `(err, response, query)` and an response is emitted as well. If the query times out the callback is called with an error.
+The `host` parameter can be an array, during resolve the lib will randomly select one host.
 
 Returns the query id
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Emitted when a dns query is received. The query is a [dns-packet](https://github
 
 Emitted when a dns response is received. The response is a [dns-packet](https://github.com/mafintosh/dns-packet)
 
-#### `var id = socket.query(query, port, host, [callback])`
+#### `var id = socket.query(query, port, [host], [callback])`
 
 Send a dns query. If host is omitted it defaults to `127.0.0.1`. When the remote replies the callback is called with `(err, response, query)` and an response is emitted as well. If the query times out the callback is called with an error.
 The `host` parameter can be an array, during resolve the lib will randomly select one host.

--- a/index.js
+++ b/index.js
@@ -111,7 +111,8 @@ DNS.prototype._ontimeoutCheck = function () {
   const now = Date.now()
   for (let i = 0; i < this.maxQueries; i++) {
     const q = this._queries[i]
-    if ((!q) || (q.firstTry + this.retries * this.timeout < now)) {
+
+    if ((!q) || (now - q.firstTry < (q.tries + 1) * this.timeout)) {
       continue
     }
 
@@ -224,7 +225,8 @@ DNS.prototype.cancel = function (id) {
 DNS.prototype.setRetries = function (id, retries) {
   const q = this._queries[id]
   if (!q) return
-  q.retries = this.retries - 1 * retries
+  q.firstTry = q.firstTry - this.timeout * (retries - q.retries)
+  q.retries = this.retries - retries;
 }
 
 DNS.prototype._getNextEmptyId = function () {

--- a/index.js
+++ b/index.js
@@ -226,7 +226,7 @@ DNS.prototype.setRetries = function (id, retries) {
   const q = this._queries[id]
   if (!q) return
   q.firstTry = q.firstTry - this.timeout * (retries - q.retries)
-  q.retries = this.retries - retries;
+  q.retries = this.retries - retries
 }
 
 DNS.prototype._getNextEmptyId = function () {

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ DNS.prototype._ontimeoutCheck = function () {
       continue
     }
     q.tries++
-    this.socket.send(q.buffer, 0, q.buffer.length, q.port, typeof q.host === 'object' ? q.host[Math.floor(q.host.length * Math.random())] : q.host)
+    this.socket.send(q.buffer, 0, q.buffer.length, q.port, Array.isArray(q.host) ? q.host[Math.floor(q.host.length * Math.random())] : q.host || '127.0.0.1')
   }
 }
 
@@ -146,7 +146,7 @@ DNS.prototype._shouldRedirect = function (q, result) {
 
   const id = this._getNextEmptyId()
   if (id === -1) {
-    q.callback('Query array is full!')
+    q.callback(new Error('Query array is full!'))
     return true
   }
 
@@ -164,7 +164,7 @@ DNS.prototype._shouldRedirect = function (q, result) {
   q.tries = 0
   q.buffer = packet.encode(q.query)
   this._queries[id] = q
-  this.socket.send(q.buffer, 0, q.buffer.length, q.port, typeof q.host === 'object' ? q.host[Math.floor(q.host.length * Math.random())] : q.host)
+  this.socket.send(q.buffer, 0, q.buffer.length, q.port, Array.isArray(q.host) ? q.host[Math.floor(q.host.length * Math.random())] : q.host || '127.0.0.1')
   return true
 }
 
@@ -179,7 +179,6 @@ DNS.prototype._onmessage = function (buffer, rinfo) {
   }
 
   if (message.type === 'response' && message.id) {
-    // const i = this._ids.indexOf(message.id);
     const q = this._queries[message.id - 1]
     if (q) {
       this._queries[message.id - 1] = null
@@ -272,7 +271,7 @@ DNS.prototype.query = function (query, port, host, cb) {
     port: port,
     host: host
   }
-  this.socket.send(buffer, 0, buffer.length, port, typeof host === 'object' ? host[Math.floor(host.length * Math.random())] : host)
+  this.socket.send(buffer, 0, buffer.length, port, Array.isArray(host) ? host[Math.floor(host.length * Math.random())] : host || '127.0.0.1')
   return id
 }
 

--- a/index.js
+++ b/index.js
@@ -8,8 +8,12 @@ const events = require('events')
 module.exports = DNS
 
 function DNS (opts) {
-  if (!(this instanceof DNS)) return new DNS(opts)
-  if (!opts) opts = {}
+  if (!(this instanceof DNS)) {
+    return new DNS(opts)
+  }
+  if (!opts) {
+    opts = {}
+  }
 
   events.EventEmitter.call(this)
 
@@ -17,14 +21,15 @@ function DNS (opts) {
 
   this.retries = opts.retries || 5
   this.timeout = opts.timeout || 7500
+  this.timeoutChecks = opts.timeoutChecks || (this.timeout / 10)
   this.destroyed = false
   this.inflight = 0
+  this.maxQueries = opts.maxQueries || 10000
+  this.maxRedirects = opts.maxRedirects || 0
   this.socket = opts.socket || dgram.createSocket('udp4')
-  this._id = Math.ceil(Math.random() * 65535)
-  this._ids = []
-  this._queries = []
+  this._id = Math.ceil(Math.random() * this.maxQueries)
+  this._queries = new Array(this.maxQueries).fill(null)
   this._interval = null
-  this._triesArray = getTriesArray(this.retries) // default: [2, 4, 8, 16] = .5s, 1s, 2s, 4s
 
   this.socket.on('error', onerror)
   this.socket.on('message', onmessage)
@@ -33,26 +38,28 @@ function DNS (opts) {
   this.socket.on('close', onclose)
 
   function onerror (err) {
-    if (err.code === 'EACCES' || err.code === 'EADDRINUSE') self.emit('error', err)
-    else self.emit('warning', err)
+    if (err.code === 'EACCES' || err.code === 'EADDRINUSE') {
+      self.emit('error', err)
+    } else {
+      self.emit('warning', err)
+    }
   }
 
   function onmessage (message, rinfo) {
     self._onmessage(message, rinfo)
   }
 
+  function ontimeoutCheck () {
+    self._ontimeoutCheck()
+  }
+
   function onlistening () {
-    const timeSlices = self._triesArray.reduce(add, 0)
-    self._interval = setInterval(ontimeout, Math.round(self.timeout / timeSlices))
+    self._interval = setInterval(ontimeoutCheck, self.timeoutChecks)
     self.emit('listening')
   }
 
   function onclose () {
     self.emit('close')
-  }
-
-  function ontimeout () {
-    self._ontimeout()
   }
 }
 
@@ -80,37 +87,84 @@ DNS.prototype.bind = function (...args) {
 }
 
 DNS.prototype.destroy = function (onclose) {
-  if (onclose) this.once('close', onclose)
-  if (this.destroyed) return
+  if (onclose) {
+    this.once('close', onclose)
+  }
+  if (this.destroyed) {
+    return
+  }
   this.destroyed = true
   clearInterval(this._interval)
   this.socket.close()
-  for (let i = 0; i < this._queries.length; i++) {
+
+  for (let i = 0; i < this.maxQueries; i++) {
     const q = this._queries[i]
-    if (q) q.callback(new Error('Socket destroyed'))
+    if (q) {
+      q.callback(new Error('Socket destroyed'))
+      this._queries[i] = null
+    }
   }
-  this._queries = []
-  this._ids = []
   this.inflight = 0
 }
 
-DNS.prototype._ontimeout = function () {
-  for (let i = 0; i < this._queries.length; i++) {
+DNS.prototype._ontimeoutCheck = function () {
+  const now = Date.now()
+  for (let i = 0; i < this.maxQueries; i++) {
     const q = this._queries[i]
-    if (!q) continue
-    if (!q.tries.length) {
+    if ((!q) || (q.firstTry + this.retries * this.timeout < now)) {
+      continue
+    }
+
+    if (q.tries > this.retries) {
       this._queries[i] = null
-      this._ids[i] = 0
       this.inflight--
       this.emit('timeout', q.query, q.port, q.host)
       q.callback(new Error('Query timed out'))
       continue
     }
-    if (--q.tries[0]) continue
-    q.tries.shift()
-    this.socket.send(q.buffer, 0, q.buffer.length, q.port, q.host)
+    q.tries++
+    this.socket.send(q.buffer, 0, q.buffer.length, q.port, typeof q.host === 'object' ? q.host[Math.floor(q.host.length * Math.random())] : q.host)
   }
-  this._trim()
+}
+
+DNS.prototype._shouldRedirect = function (q, result) {
+  // no redirects, no query, more than 1 questions, has any A record answer
+  if (this.maxRedirects <= 0 || (!q) || (q.query.questions.length !== 1) || result.answers.filter(e => e.type === 'A').length > 0) {
+    return false
+  }
+
+  // no more redirects left
+  if (q.redirects > this.maxRedirects) {
+    return false
+  }
+
+  const cnameresults = result.answers.filter(e => e.type === 'CNAME')
+  if (cnameresults.length === 0) {
+    return false
+  }
+
+  const id = this._getNextEmptyId()
+  if (id === -1) {
+    q.callback('Query array is full!')
+    return true
+  }
+
+  // replace current query with a new one
+  q.query = {
+    id: id + 1,
+    flags: packet.RECURSION_DESIRED,
+    questions: [{
+      type: 'A',
+      name: cnameresults[0].data
+    }]
+  }
+  q.redirects++
+  q.firstTry = Date.now()
+  q.tries = 0
+  q.buffer = packet.encode(q.query)
+  this._queries[id] = q
+  this.socket.send(q.buffer, 0, q.buffer.length, q.port, typeof q.host === 'object' ? q.host[Math.floor(q.host.length * Math.random())] : q.host)
+  return true
 }
 
 DNS.prototype._onmessage = function (buffer, rinfo) {
@@ -124,25 +178,19 @@ DNS.prototype._onmessage = function (buffer, rinfo) {
   }
 
   if (message.type === 'response' && message.id) {
-    const i = this._ids.indexOf(message.id)
-    const q = i > -1 ? this._queries[i] : null
+    // const i = this._ids.indexOf(message.id);
+    const q = this._queries[message.id - 1]
     if (q) {
+      this._queries[message.id - 1] = null
       this.inflight--
-      this._ids[i] = 0
-      this._queries[i] = null
-      this._trim()
-      q.callback(null, message, q.query, rinfo.port, rinfo.address)
+
+      if (!this._shouldRedirect(q, message)) {
+        q.callback(null, message)
+      }
     }
   }
 
   this.emit(message.type, message, rinfo.port, rinfo.address)
-}
-
-DNS.prototype._trim = function () {
-  while (this._ids.length && !this._ids[this._ids.length - 1]) {
-    this._ids.pop()
-    this._queries.pop()
-  }
 }
 
 DNS.prototype.unref = function () {
@@ -154,94 +202,79 @@ DNS.prototype.ref = function () {
 }
 
 DNS.prototype.response = function (query, response, port, host) {
-  if (this.destroyed) return
+  if (this.destroyed) {
+    return
+  }
 
   response.type = 'response'
   response.id = query.id
-
   const buffer = packet.encode(response)
-  this.socket.send(buffer, 0, buffer.length, port, host || '127.0.0.1')
+  this.socket.send(buffer, 0, buffer.length, port, host)
 }
 
 DNS.prototype.cancel = function (id) {
-  const i = this._ids.indexOf(id)
-  const q = this._queries[i]
+  const q = this._queries[id]
   if (!q) return
 
-  this._queries[i] = null
-  this._ids[i] = 0
+  this._queries[id] = null
   this.inflight--
   q.callback(new Error('Query cancelled'))
 }
 
 DNS.prototype.setRetries = function (id, retries) {
-  const i = this._ids.indexOf(id)
-  const q = this._queries[i]
+  const q = this._queries[id]
   if (!q) return
+  q.retries = this.retries - 1 * retries
+}
 
-  while (q.tries.length < retries) {
-    q.tries.push(q.tries.length ? 2 * q.tries[q.tries.length - 1] : 4)
+DNS.prototype._getNextEmptyId = function () {
+  // try to find the next unused id
+  let id = -1
+  for (let idtries = this.maxQueries; idtries > 0; idtries--) {
+    const normalizedId = (this._id + idtries) % this.maxQueries
+    if (this._queries[normalizedId] === null) {
+      id = normalizedId
+      this._id = (normalizedId + 1) % this.maxQueries
+      break
+    }
   }
-  if (q.tries.length > retries) {
-    q.tries = q.tries.slice(0, retries)
-  }
+  return id
 }
 
 DNS.prototype.query = function (query, port, host, cb) {
-  if (typeof host === 'function') return this.query(query, port, null, host)
-  if (!cb) cb = noop
-
   if (this.destroyed) {
-    nextTick(cb, new Error('Socket destroyed'))
+    cb(new Error('Socket destroyed'))
     return 0
   }
 
   this.inflight++
   query.type = 'query'
   query.flags = typeof query.flags === 'number' ? query.flags : DNS.RECURSION_DESIRED
-  const id = query.id = this._id++
-  if (this._id === 65535) this._id = 1
 
-  let i = this._ids.indexOf(0)
-  if (i === -1) i = this._ids.push(0) - 1
-  if (this._queries.length === i) this._queries.push(null)
+  const id = this._getNextEmptyId()
+  if (id === -1) {
+    cb(new Error('Query array is full!'))
+    return 0
+  }
 
+  query.id = id + 1
   const buffer = packet.encode(query)
-  const tries = this._triesArray.slice(0)
 
-  this._ids[i] = id
-  this._queries[i] = {
-    callback: cb,
-    tries: tries,
+  this._queries[id] = {
+    callback: cb || noop,
+    redirects: 0,
+    firstTry: Date.now(),
     query: query,
+    tries: 0,
     buffer: buffer,
     port: port,
     host: host
   }
-
-  this.socket.send(buffer, 0, buffer.length, port, host || '127.0.0.1')
+  this.socket.send(buffer, 0, buffer.length, port, typeof host === 'object' ? host[Math.floor(host.length * Math.random())] : host)
   return id
 }
 
-function noop () {}
-
-function nextTick (cb, err) {
-  process.nextTick(function () {
-    cb(err)
-  })
-}
-
-function add (a, b) {
-  return a + b
-}
-
-function getTriesArray (retries) {
-  const ret = []
-  if (retries <= 1) return ret
-  for (let i = 1; i <= retries - 1; i++) {
-    ret.push(Math.pow(2, i))
-  }
-  return ret
+function noop () {
 }
 
 function isListening (socket) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "eslint --color *.js && tape test.js"
   },
   "dependencies": {
-    "dns-packet": "^5.1.1"
+    "dns-packet": "^5.1.2"
   },
   "devDependencies": {
     "eslint": "^5.12.1",

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ tape('query + response', function (t) {
         type: 'A',
         name: 'test'
       }]
-    }, socket.address().port, function (err, res) {
+    }, socket.address().port, socket.address().host, function (err, res) {
       socket.destroy()
       t.error(err)
       t.same(res.answers.length, 1)
@@ -58,7 +58,7 @@ tape('pass socket + query + response', function (t) {
         type: 'A',
         name: 'test'
       }]
-    }, socket.address().port, function (err, res) {
+    }, socket.address().port, socket.address().host, function (err, res) {
       socket.destroy()
       t.error(err)
       t.same(res.answers.length, 1)
@@ -87,7 +87,7 @@ tape('timeout', function (t) {
 
     const id = socket.query({
       questions: [{ type: 'A', name: 'test' }]
-    }, dummy.address().port, function (err) {
+    }, dummy.address().port, dummy.address().host, function (err) {
       if (done) return
       clearTimeout(timeout)
       socket.destroy()
@@ -119,7 +119,7 @@ tape('pass socket + timeout', function (t) {
 
       const id = socket.query({
         questions: [{ type: 'A', name: 'test' }]
-      }, dummy.address().port, function (err) {
+      }, dummy.address().port, socket.address().host, function (err) {
         if (done) return
         clearTimeout(timeout)
         socket.destroy()
@@ -153,7 +153,7 @@ tape('two queries + response', function (t) {
         type: 'A',
         name: 'test1'
       }]
-    }, socket.address().port, function (err, res) {
+    }, socket.address().port, socket.address().host, function (err, res) {
       t.error(err)
       t.same(res.answers.length, 1)
       t.same(res.answers[0].type, 'A')
@@ -167,7 +167,7 @@ tape('two queries + response', function (t) {
         type: 'A',
         name: 'test2'
       }]
-    }, socket.address().port, function (err, res) {
+    }, socket.address().port, socket.address().host, function (err, res) {
       t.error(err)
       t.same(res.answers.length, 1)
       t.same(res.answers[0].type, 'A')


### PR DESCRIPTION
First of all, this is really nice library. I tried to use it to resolve 10k dns records in a meaningful way, and the retry / timeout logic resulted in mostly timeouts. The memory usage and gc cpu usage also went up if I did 40k queries parallel.

So I started to dig around, and changed the _id and _queries structure to a more static one, changing the timeout and retry logic, extending the host parameter to accept arrays and randomly pick from them. 

There was an issue #15 which also needed to be resolved for my use-case, so I extended the library to support them.

The only "breaking" change is that the host parameter is not an optional one any more, that's why I modified the tests - otherwise for an average user it looks and works the same.

This PR has a slight memory advantage over the original one, the host and retry logic might be useful for someone else as well.

Let me know if you want to have any modifications, etc.