### PR TITLE
fix zero retries

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function DNS (opts) {
 
   const self = this
 
-  this.retries = opts.retries || 5
+  this.retries = opts.retries !== undefined ? opts.retries : 5
   this.timeout = opts.timeout || 7500
   this.timeoutChecks = opts.timeoutChecks || (this.timeout / 10)
   this.destroyed = false


### PR DESCRIPTION
At this moment:
```js
const socket = dns({ retries: 0 })
console.log(socket.retries) // => 5
```
With this pull request the previous example works as should be (prints zero), there will be no retries.