### PR TITLE
Bump dns-packet to ^5.2.4 (take 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "eslint --color *.js && tape test.js"
   },
   "dependencies": {
-    "dns-packet": "^5.1.2"
+    "dns-packet": "^5.2.4"
   },
   "devDependencies": {
     "eslint": "^5.12.1",


### PR DESCRIPTION
Address vulnerability [CVE-2021-23386](https://nvd.nist.gov/vuln/detail/CVE-2021-23386).
All tests pass.

Supersedes #23 which included a superfluous merge commit.